### PR TITLE
Add config with serials for correct labeling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,33 @@ plt.ylabel('X Coordinate (meters)')
 ```
 
 ![Example plot of captured data](images/simple_xcoord_plot.png "Example Plot")
+
+# Configuration file
+
+The goal is to identify devices by serial, in order to keep the same name for the same physical device. for maing it work, you just have to change serials and names in the 'config.json' file. Here is an example of config file :
+
+```
+{
+    "devices":[
+        {
+          "name": "hmd",
+          "type": "HMD",
+          "serial":"XXX-XXXXXXXX"
+        },
+        {
+          "name": "tracking_reference_1",
+          "type": "Tracking Reference",
+          "serial":"LHB-XXXXXXXX"
+        },
+        {
+          "name": "controller_1",
+          "type": "Controller",
+          "serial":"XXX-XXXXXXXX"
+        },
+        {
+          "name": "tracker_1",
+          "type": "Tracker",
+          "serial":"LHR-XXXXXXXX"
+        }
+}
+```

--- a/README.md
+++ b/README.md
@@ -44,5 +44,6 @@ The goal is to identify devices by serial, in order to keep the same name for th
           "type": "Tracker",
           "serial":"LHR-XXXXXXXX"
         }
+    ]
 }
 ```

--- a/config.json
+++ b/config.json
@@ -1,0 +1,29 @@
+{
+    "devices":[
+        {
+          "name": "tracking_reference_0",
+          "type": "Tracking Reference",
+          "serial":"LHB-02F97E98"
+        },
+        {
+          "name": "tracking_reference_1",
+          "type": "Tracking Reference",
+          "serial":"LHB-431A55FD"
+        },
+        {
+          "name": "tracker_0",
+          "type": "Tracker",
+          "serial":"LHR-3CD1A9DA"
+        },
+        {
+          "name": "tracker_1",
+          "type": "Tracker",
+          "serial":"LHR-25865D81"
+        },
+        {
+          "name": "tracker_2",
+          "type": "Tracker",
+          "serial":"LHR-4359D2B6"
+        }
+    ]
+}

--- a/triad_openvr.py
+++ b/triad_openvr.py
@@ -2,6 +2,7 @@ import time
 import sys
 import openvr
 import math
+import json
 
 # Function to print out text but instead of starting a new line it will overwrite the existing line
 def update_text(txt):
@@ -47,7 +48,7 @@ class pose_sample_buffer():
         self.r_x = []
         self.r_y = []
         self.r_z = []
-    
+
     def append(self,pose_mat,t):
         self.time.append(t)
         self.x.append(pose_mat[0][3])
@@ -67,13 +68,13 @@ class vr_tracked_device():
         self.device_class = device_class
         self.index = index
         self.vr = vr_obj
-        
+
     def get_serial(self):
         return self.vr.getStringTrackedDeviceProperty(self.index,openvr.Prop_SerialNumber_String).decode('utf-8')
-    
+
     def get_model(self):
         return self.vr.getStringTrackedDeviceProperty(self.index,openvr.Prop_ModelNumber_String).decode('utf-8')
-        
+
     def sample(self,num_samples,sample_rate):
         interval = 1/sample_rate
         rtn = pose_sample_buffer()
@@ -86,11 +87,11 @@ class vr_tracked_device():
             if sleep_time>0:
                 time.sleep(sleep_time)
         return rtn
-        
+
     def get_pose_euler(self):
         pose = self.vr.getDeviceToAbsoluteTrackingPose(openvr.TrackingUniverseStanding, 0,openvr.k_unMaxTrackedDeviceCount)
         return convert_to_euler(pose[self.index].mDeviceToAbsoluteTracking)
-    
+
     def get_pose_quaternion(self):
         pose = self.vr.getDeviceToAbsoluteTrackingPose(openvr.TrackingUniverseStanding, 0,openvr.k_unMaxTrackedDeviceCount)
         return convert_to_quaternion(pose[self.index].mDeviceToAbsoluteTracking)
@@ -100,45 +101,65 @@ class vr_tracking_reference(vr_tracked_device):
         return self.vr.getStringTrackedDeviceProperty(self.index,openvr.Prop_ModeLabel_String).decode('utf-8').upper()
     def sample(self,num_samples,sample_rate):
         print("Warning: Tracking References do not move, sample isn't much use...")
-        
+
 class triad_openvr():
     def __init__(self):
-        # Initialize OpenVR in the 
+        # Initialize OpenVR in the
         self.vr = openvr.init(openvr.VRApplication_Other)
-        
-        # Initializing object to hold indexes for various tracked objects 
+
+        # Initializing object to hold indexes for various tracked objects
         self.object_names = {"Tracking Reference":[],"HMD":[],"Controller":[],"Tracker":[]}
         self.devices = {}
         poses = self.vr.getDeviceToAbsoluteTrackingPose(openvr.TrackingUniverseStanding, 0,
                                                                openvr.k_unMaxTrackedDeviceCount)
-        # Iterate through the pose list to find the active devices and determine their type
-        for i in range(openvr.k_unMaxTrackedDeviceCount):
-            if poses[i].bPoseIsValid:
-                device_class = self.vr.getTrackedDeviceClass(i)
-                if (device_class == openvr.TrackedDeviceClass_Controller):
-                    device_name = "controller_"+str(len(self.object_names["Controller"])+1)
-                    self.object_names["Controller"].append(device_name)
-                    self.devices[device_name] = vr_tracked_device(self.vr,i,"Controller")
-                elif (device_class == openvr.TrackedDeviceClass_HMD):
-                    device_name = "hmd_"+str(len(self.object_names["HMD"])+1)
-                    self.object_names["HMD"].append(device_name)
-                    self.devices[device_name] = vr_tracked_device(self.vr,i,"HMD")
-                elif (device_class == openvr.TrackedDeviceClass_GenericTracker):
-                    device_name = "tracker_"+str(len(self.object_names["Tracker"])+1)
-                    self.object_names["Tracker"].append(device_name)
-                    self.devices[device_name] = vr_tracked_device(self.vr,i,"Tracker")
-                elif (device_class == openvr.TrackedDeviceClass_TrackingReference):
-                    device_name = "tracking_reference_"+str(len(self.object_names["Tracking Reference"])+1)
-                    self.object_names["Tracking Reference"].append(device_name)
-                    self.devices[device_name] = vr_tracking_reference(self.vr,i,"Tracking Reference")
-    
+
+        # Loading config file
+        self.config = None
+        try:
+            with open('config.json') as json_data:
+                self.config = json.load(json_data)
+        except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+            print('config.json not found, arbitrary id will be chosen.')
+
+        if self.config != None:
+            # Iterate through the pose list to find the active devices and determine their type
+            for i in range(openvr.k_unMaxTrackedDeviceCount):
+                if poses[i].bPoseIsValid:
+                    device_serial = self.vr.getStringTrackedDeviceProperty(i,openvr.Prop_SerialNumber_String).decode('utf-8')
+                    for device in self.config['devices']:
+                        if device_serial == device['serial']:
+                            device_name = device['name']
+                            self.object_names[device['type']].append(device_name)
+                            self.devices[device_name] = vr_tracked_device(self.vr,i,device['type'])
+        else:
+            # Iterate through the pose list to find the active devices and determine their type
+            for i in range(openvr.k_unMaxTrackedDeviceCount):
+                if poses[i].bPoseIsValid:
+                    device_class = self.vr.getTrackedDeviceClass(i)
+                    if (device_class == openvr.TrackedDeviceClass_Controller):
+                        device_name = "controller_"+str(len(self.object_names["Controller"])+1)
+                        self.object_names["Controller"].append(device_name)
+                        self.devices[device_name] = vr_tracked_device(self.vr,i,"Controller")
+                    elif (device_class == openvr.TrackedDeviceClass_HMD):
+                        device_name = "hmd_"+str(len(self.object_names["HMD"])+1)
+                        self.object_names["HMD"].append(device_name)
+                        self.devices[device_name] = vr_tracked_device(self.vr,i,"HMD")
+                    elif (device_class == openvr.TrackedDeviceClass_GenericTracker):
+                        device_name = "tracker_"+str(len(self.object_names["Tracker"])+1)
+                        self.object_names["Tracker"].append(device_name)
+                        self.devices[device_name] = vr_tracked_device(self.vr,i,"Tracker")
+                    elif (device_class == openvr.TrackedDeviceClass_TrackingReference):
+                        device_name = "tracking_reference_"+str(len(self.object_names["Tracking Reference"])+1)
+                        self.object_names["Tracking Reference"].append(device_name)
+                        self.devices[device_name] = vr_tracking_reference(self.vr,i,"Tracking Reference")
+
     def rename_device(self,old_device_name,new_device_name):
         self.devices[new_device_name] = self.devices.pop(old_device_name)
         for i in range(len(self.object_names[self.devices[new_device_name].device_class])):
             if self.object_names[self.devices[new_device_name].device_class][i] == old_device_name:
                 self.object_names[self.devices[new_device_name].device_class][i] = new_device_name
-    
-    def print_discovered_objects(self):   
+
+    def print_discovered_objects(self):
         for device_type in self.object_names:
             plural = device_type
             if len(self.object_names[device_type])!=1:
@@ -147,7 +168,7 @@ class triad_openvr():
             for device in self.object_names[device_type]:
                 if device_type == "Tracking Reference":
                     print("  "+device+" ("+self.devices[device].get_serial()+
-                          ", Mode "+self.devices[device].get_mode()+
+                          ", Mode "+self.devices[device].get_model()+
                           ", "+self.devices[device].get_model()+
                           ")")
                 else:


### PR DESCRIPTION
Hi, 

I wanted to keep consistency between real world controllers and trackers names (which are labeled) and available names in the software. so i just added the possibility to configure names associated with serials in a `config.json` file. The current process tries to read this file to assign corresponding names to devices. if it fails, the previous normal behavior is used. 

I hope it can be usefull for someone :).