### PR TITLE
Fix argument for interval

### DIFF
--- a/controller_test.py
+++ b/controller_test.py
@@ -8,7 +8,7 @@ v.print_discovered_objects()
 if len(sys.argv) == 1:
     interval = 1/250
 elif len(sys.argv) == 2:
-    interval = 1/float(sys.argv[0])
+    interval = 1/float(sys.argv[1])
 else:
     print("Invalid number of arguments")
     interval = False

--- a/tracker_test.py
+++ b/tracker_test.py
@@ -8,7 +8,7 @@ v.print_discovered_objects()
 if len(sys.argv) == 1:
     interval = 1/250
 elif len(sys.argv) == 2:
-    interval = 1/float(sys.argv[0])
+    interval = 1/float(sys.argv[1])
 else:
     print("Invalid number of arguments")
     interval = False

--- a/udp_emitter.py
+++ b/udp_emitter.py
@@ -13,7 +13,7 @@ v.print_discovered_objects()
 if len(sys.argv) == 1:
     interval = 1/250
 elif len(sys.argv) == 2:
-    interval = 1/float(sys.argv[0])
+    interval = 1/float(sys.argv[1])
 else:
     print("Invalid number of arguments")
     interval = False


### PR DESCRIPTION
The argument for setting the interval is incorrect. \
When using `sys.argv` and the code called from a script, argv[0] is the name of the script (ie. `"tracker_test.py"`, while argv[1] is the argument entered.